### PR TITLE
Tweaking tract hunter algorithm 

### DIFF
--- a/R/run_tract_hunter.R
+++ b/R/run_tract_hunter.R
@@ -267,7 +267,6 @@ tract_hunter_asu_pass <- function(state, verbose = TRUE) {
     unemp_buffer    <- total_new_unemp
 
     while (new_ur < ur_thresh) {
-      drop_candidates <- drop_candidates[ unemp_vec[drop_candidates] < unemp_buffer ]
       if (length(drop_candidates) == 0) return(FALSE)
 
       drop_res <- choose_best_drop_candidate(drop_candidates,
@@ -299,7 +298,6 @@ tract_hunter_asu_pass <- function(state, verbose = TRUE) {
       cut_verts <- if (length(cp) > 0) union_indexes[cp] else integer(0)
       invalid_drop_ids <- c(cut_verts, new_indexes)
       drop_candidates <- setdiff(remaining_indexes, invalid_drop_ids)
-      drop_candidates <- drop_candidates[ unemp_vec[drop_candidates] < unemp_buffer ]
       if (length(drop_candidates) == 0) return(FALSE)
     }
 
@@ -343,7 +341,6 @@ tract_hunter_asu_pass <- function(state, verbose = TRUE) {
 
       if (isTRUE(ok)) {
         successful_update <- TRUE
-        break
       }
     }
 


### PR DESCRIPTION
This pull request simplifies the logic in the `tract_hunter_asu_pass` function in the `R/run_tract_hunter.R` file by removing redundant operations and improving code readability. It also improves the automatic construction of ASUs

### Simplifications in `tract_hunter_asu_pass` function:

* Removed redundant filtering of `drop_candidates` based on `unemp_vec` and `unemp_buffer`, as this operation was unnecessary in two locations. [[1]](diffhunk://#diff-64e771a5a328ead387b2d6bfb37c14991f90aa6dad6d23e6bbcec422441bf9b0L270) [[2]](diffhunk://#diff-64e771a5a328ead387b2d6bfb37c14991f90aa6dad6d23e6bbcec422441bf9b0L302)
* Eliminated an `break` statement within the loop after a successful update which was cancelling the loop early